### PR TITLE
Make git clone depth configurable

### DIFF
--- a/res/composer-schema.json
+++ b/res/composer-schema.json
@@ -238,6 +238,10 @@
                         "type": "string"
                     }
                 },
+                "git-clone-depth": {
+                    "type": "integer",
+                    "description": "Defaults to 1 (shallow clone). Set to the desired history size. If set to -1, the source will be cloned in full."
+                },
                 "github-expose-hostname": {
                     "type": "boolean",
                     "description": "Defaults to true. If set to false, the OAuth tokens created to access the github API will have a date instead of the machine hostname."

--- a/src/Composer/Command/ConfigCommand.php
+++ b/src/Composer/Command/ConfigCommand.php
@@ -340,6 +340,7 @@ EOT
                 function ($val) { return is_dir($val) && is_readable($val); },
                 function ($val) { return $val === 'null' ? null : $val; },
             ),
+            'git-clone-depth' => array('is_numeric', 'intval'),
             'github-expose-hostname' => array($booleanValidator, $booleanNormalizer),
         );
         $multiConfigValues = array(

--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -49,6 +49,7 @@ class Config
         'secure-http' => true,
         'cafile' => null,
         'capath' => null,
+        'git-clone-depth' => 1,
         'github-expose-hostname' => true,
         'gitlab-domains' => array('gitlab.com'),
         'store-auths' => 'prompt',

--- a/src/Composer/Downloader/GitDownloader.php
+++ b/src/Composer/Downloader/GitDownloader.php
@@ -45,7 +45,11 @@ class GitDownloader extends VcsDownloader
 
         $ref = $package->getSourceReference();
         $flag = Platform::isWindows() ? '/D ' : '';
-        $command = '(git clone --no-checkout --depth 1 --single-branch %s %s --branch %s || git clone --no-checkout %1$s %2$s)'.
+        $cloneDepth = '';
+        if ($this->config->get('git-clone-depth') !== -1) {
+            $cloneDepth = '--depth '.$this->config->get('git-clone-depth');
+        }
+        $command = '(git clone --no-checkout '.$cloneDepth.' --single-branch %s %s --branch %s || git clone --no-checkout %1$s %2$s)'.
             ' && cd '.$flag.'%2$s && git remote add composer %1$s && (git fetch composer %3$s || git fetch composer)';
         $this->io->writeError("    Cloning ".$ref);
 


### PR DESCRIPTION
The clone depth is now configurable by setting `git-clone-depth` in the config section. The default is 1. You can set any depth you wish. If you set it to -1, the full source will be fetched.
