### PR TITLE
Add return types to tests

### DIFF
--- a/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
+++ b/tests/Composer/Test/Autoload/AutoloadGeneratorTest.php
@@ -100,10 +100,10 @@ class AutoloadGeneratorTest extends TestCase
         $this->config = $this->getMockBuilder('Composer\Config')->getMock();
 
         $this->configValueMap = array(
-            'vendor-dir' => function () {
+            'vendor-dir' => function (): string {
                 return $this->vendorDir;
             },
-            'platform-check' => function () {
+            'platform-check' => function (): bool {
                 return true;
             },
         );
@@ -130,7 +130,7 @@ class AutoloadGeneratorTest extends TestCase
             ->getMock();
         $this->im->expects($this->any())
             ->method('getInstallPath')
-            ->will($this->returnCallback(function ($package) {
+            ->will($this->returnCallback(function ($package): string {
                 $targetDir = $package->getTargetDir();
 
                 return $this->vendorDir.'/'.$package->getName() . ($targetDir ? '/'.$targetDir : '');
@@ -1354,7 +1354,7 @@ EOF;
             ->getMock();
         $im->expects($this->any())
             ->method('getInstallPath')
-            ->will($this->returnCallback(function ($package) use ($vendorDir) {
+            ->will($this->returnCallback(function ($package) use ($vendorDir): string {
                 $targetDir = $package->getTargetDir();
 
                 return $vendorDir.'/'.$package->getName() . ($targetDir ? '/'.$targetDir : '');

--- a/tests/Composer/Test/Command/RunScriptCommandTest.php
+++ b/tests/Composer/Test/Command/RunScriptCommandTest.php
@@ -61,7 +61,7 @@ class RunScriptCommandTest extends TestCase
 
         $ed->expects($this->once())
             ->method('hasEventListeners')
-            ->with($this->callback(function (ScriptEvent $event) use ($scriptName, $expectedDevMode) {
+            ->with($this->callback(function (ScriptEvent $event) use ($scriptName, $expectedDevMode): bool {
                 return $event->getName() === $scriptName
                 && $event->isDevMode() === $expectedDevMode;
             }))

--- a/tests/Composer/Test/Config/JsonConfigSourceTest.php
+++ b/tests/Composer/Test/Config/JsonConfigSourceTest.php
@@ -174,7 +174,7 @@ class JsonConfigSourceTest extends TestCase
     /**
      * Provide data for testAddLink
      */
-    public function provideAddLinkData()
+    public function provideAddLinkData(): array
     {
         $empty = $this->fixturePath('composer-empty.json');
         $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
@@ -230,7 +230,7 @@ class JsonConfigSourceTest extends TestCase
     /**
      * Provide data for testRemoveLink
      */
-    public function provideRemoveLinkData()
+    public function provideRemoveLinkData(): array
     {
         $oneOfEverything = $this->fixturePath('composer-one-of-everything.json');
         $twoOfEverything = $this->fixturePath('composer-two-of-everything.json');

--- a/tests/Composer/Test/ConfigTest.php
+++ b/tests/Composer/Test/ConfigTest.php
@@ -34,7 +34,7 @@ class ConfigTest extends TestCase
         $this->assertEquals($expected, $config->getRepositories());
     }
 
-    public function dataAddPackagistRepository()
+    public function dataAddPackagistRepository(): array
     {
         $data = array();
         $data['local config inherits system defaults'] = array(
@@ -282,7 +282,7 @@ class ConfigTest extends TestCase
             'ssh://[user@]host.xz[:port]/path/to/repo.git/',
         );
 
-        return array_combine($urls, array_map(function ($e) {
+        return array_combine($urls, array_map(function ($e): array {
             return array($e);
         }, $urls));
     }
@@ -303,7 +303,7 @@ class ConfigTest extends TestCase
             'git://5.6.7.8/git.git',
         );
 
-        return array_combine($urls, array_map(function ($e) {
+        return array_combine($urls, array_map(function ($e): array {
             return array($e);
         }, $urls));
     }

--- a/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolBuilderTest.php
@@ -50,7 +50,7 @@ class PoolBuilderTest extends TestCase
         $minimumStability = !empty($root['minimum-stability']) ? $root['minimum-stability'] : 'stable';
         $stabilityFlags = !empty($root['stability-flags']) ? $root['stability-flags'] : array();
         $rootReferences = !empty($root['references']) ? $root['references'] : array();
-        $stabilityFlags = array_map(function ($stability) {
+        $stabilityFlags = array_map(function ($stability): int {
             return BasePackage::$stabilities[$stability];
         }, $stabilityFlags);
 
@@ -62,7 +62,7 @@ class PoolBuilderTest extends TestCase
 
         $loader = new ArrayLoader(null, true);
         $packageIds = array();
-        $loadPackage = function ($data) use ($loader, &$packageIds) {
+        $loadPackage = function ($data) use ($loader, &$packageIds): \Composer\Package\PackageInterface {
             /** @var ?int $id */
             $id = null;
             if (!empty($data['id'])) {

--- a/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
+++ b/tests/Composer/Test/DependencyResolver/PoolOptimizerTest.php
@@ -71,7 +71,7 @@ class PoolOptimizerTest extends TestCase
         );
     }
 
-    public function provideIntegrationTests()
+    public function provideIntegrationTests(): array
     {
         $fixturesDir = realpath(__DIR__.'/Fixtures/pooloptimizer/');
         $tests = array();

--- a/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/ArchiveDownloaderTest.php
@@ -115,7 +115,7 @@ class ArchiveDownloaderTest extends TestCase
         $this->assertEquals($expected, $url);
     }
 
-    public function provideUrls()
+    public function provideUrls(): array
     {
         return array(
             array('https://api.github.com/repos/composer/composer/zipball/master'),
@@ -154,7 +154,7 @@ class ArchiveDownloaderTest extends TestCase
         $this->assertEquals($expected, $url);
     }
 
-    public function provideBitbucketUrls()
+    public function provideBitbucketUrls(): array
     {
         return array(
             array('https://bitbucket.org/davereid/drush-virtualhost/get/77ca490c26ac818e024d1138aa8bd3677d1ef21f', 'zip'),

--- a/tests/Composer/Test/Downloader/DownloadManagerTest.php
+++ b/tests/Composer/Test/Downloader/DownloadManagerTest.php
@@ -666,7 +666,7 @@ class DownloadManagerTest extends TestCase
         $this->assertEquals($expected, $method->invoke($manager, $target, $initial ?? null));
     }
 
-    public static function updatesProvider()
+    public static function updatesProvider(): array
     {
         return array(
             //    prevPkg source,  prevPkg isDev, pkg available,           pkg isDev,  expected

--- a/tests/Composer/Test/Downloader/FileDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/FileDownloaderTest.php
@@ -228,7 +228,7 @@ class FileDownloaderTest extends TestCase
         $cacheMock
             ->expects($this->any())
             ->method('copyTo')
-            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey) {
+            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey): bool {
                 $this->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyTo method:');
 
                 return false;
@@ -236,7 +236,7 @@ class FileDownloaderTest extends TestCase
         $cacheMock
             ->expects($this->any())
             ->method('copyFrom')
-            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey) {
+            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey): bool {
                 $this->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyFrom method:');
 
                 return false;
@@ -328,7 +328,7 @@ class FileDownloaderTest extends TestCase
         $cacheMock
             ->expects($this->any())
             ->method('copyTo')
-            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey) {
+            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey): bool {
                 $this->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyTo method:');
 
                 return false;
@@ -336,7 +336,7 @@ class FileDownloaderTest extends TestCase
         $cacheMock
             ->expects($this->any())
             ->method('copyFrom')
-            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey) {
+            ->will($this->returnCallback(function ($cacheKey) use ($expectedCacheKey): bool {
                 $this->assertEquals($expectedCacheKey, $cacheKey, 'Failed assertion on $cacheKey argument of Cache::copyFrom method:');
 
                 return false;

--- a/tests/Composer/Test/Downloader/GitDownloaderTest.php
+++ b/tests/Composer/Test/Downloader/GitDownloaderTest.php
@@ -220,7 +220,7 @@ class GitDownloaderTest extends TestCase
         $downloader->cleanup('install', $packageMock, 'composerPath');
     }
 
-    public function pushUrlProvider()
+    public function pushUrlProvider(): array
     {
         return array(
             // ssh proto should use git@ all along

--- a/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Composer/Test/EventDispatcher/EventDispatcherTest.php
@@ -120,7 +120,7 @@ class EventDispatcherTest extends TestCase
         $dispatcher->hasEventListeners($event);
     }
 
-    public function provideDevModes()
+    public function provideDevModes(): array
     {
         return array(
             array(true),
@@ -382,7 +382,7 @@ class EventDispatcherTest extends TestCase
 
         $dispatcher->expects($this->atLeastOnce())
             ->method('getListeners')
-            ->will($this->returnCallback(function (Event $event) {
+            ->will($this->returnCallback(function (Event $event): array {
                 if ($event->getName() === 'root') {
                     return array('@group');
                 }
@@ -427,7 +427,7 @@ class EventDispatcherTest extends TestCase
 
         $dispatcher->expects($this->atLeastOnce())
             ->method('getListeners')
-            ->will($this->returnCallback(function (Event $event) {
+            ->will($this->returnCallback(function (Event $event): array {
                 if ($event->getName() === 'hello') {
                     return array('echo Hello');
                 }
@@ -463,7 +463,7 @@ class EventDispatcherTest extends TestCase
 
         $dispatcher->expects($this->atLeastOnce())
             ->method('getListeners')
-            ->will($this->returnCallback(function (Event $event) {
+            ->will($this->returnCallback(function (Event $event): array {
                 if ($event->getName() === 'root') {
                     return array('@recurse');
                 }
@@ -500,7 +500,7 @@ class EventDispatcherTest extends TestCase
         return $dispatcher;
     }
 
-    public function provideValidCommands()
+    public function provideValidCommands(): array
     {
         return array(
             array('phpunit'),

--- a/tests/Composer/Test/IO/ConsoleIOTest.php
+++ b/tests/Composer/Test/IO/ConsoleIOTest.php
@@ -83,7 +83,7 @@ class ConsoleIOTest extends TestCase
         $outputMock->expects($this->once())
             ->method('write')
             ->with(
-                $this->callback(function ($messages) {
+                $this->callback(function ($messages): bool {
                     $result = Preg::isMatch("[(.*)/(.*) First line]", $messages[0]);
                     $result = $result && Preg::isMatch("[(.*)/(.*) Second line]", $messages[1]);
 
@@ -209,7 +209,7 @@ class ConsoleIOTest extends TestCase
             ->will($this->returnValue($helperMock))
         ;
 
-        $validator = function ($value) {
+        $validator = function ($value): bool {
             return true;
         };
         $consoleIO = new ConsoleIO($inputMock, $outputMock, $setMock);

--- a/tests/Composer/Test/IO/NullIOTest.php
+++ b/tests/Composer/Test/IO/NullIOTest.php
@@ -65,7 +65,7 @@ class NullIOTest extends TestCase
     {
         $io = new NullIO();
 
-        $this->assertEquals('foo', $io->askAndValidate('question', function ($x) {
+        $this->assertEquals('foo', $io->askAndValidate('question', function ($x): bool {
             return true;
         }, null, 'foo'));
     }

--- a/tests/Composer/Test/InstalledVersionsTest.php
+++ b/tests/Composer/Test/InstalledVersionsTest.php
@@ -79,7 +79,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::isInstalled($name, $includeDevRequirements));
     }
 
-    public static function isInstalledProvider()
+    public static function isInstalledProvider(): array
     {
         return array(
             array(true,  'foo/impl'),
@@ -104,7 +104,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::satisfies(new VersionParser, $name, $constraint));
     }
 
-    public static function satisfiesProvider()
+    public static function satisfiesProvider(): array
     {
         return array(
             array(true,  'foo/impl', '1.5'),
@@ -144,7 +144,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::getVersionRanges($name));
     }
 
-    public static function getVersionRangesProvider()
+    public static function getVersionRangesProvider(): array
     {
         return array(
             array('dev-master || 1.10.x-dev',   '__root__'),
@@ -168,7 +168,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::getVersion($name));
     }
 
-    public static function getVersionProvider()
+    public static function getVersionProvider(): array
     {
         return array(
             array('dev-master',  '__root__'),
@@ -192,7 +192,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::getPrettyVersion($name));
     }
 
-    public static function getPrettyVersionProvider()
+    public static function getPrettyVersionProvider(): array
     {
         return array(
             array('dev-master',  '__root__'),
@@ -247,7 +247,7 @@ class InstalledVersionsTest extends TestCase
         $this->assertSame($expected, InstalledVersions::getReference($name));
     }
 
-    public static function getReferenceProvider()
+    public static function getReferenceProvider(): array
     {
         return array(
             array('sourceref-by-default',  '__root__'),

--- a/tests/Composer/Test/Installer/BinaryInstallerTest.php
+++ b/tests/Composer/Test/Installer/BinaryInstallerTest.php
@@ -87,7 +87,7 @@ class BinaryInstallerTest extends TestCase
         $this->assertEquals('success arg', $output);
     }
 
-    public function executableBinaryProvider()
+    public function executableBinaryProvider(): array
     {
         return array(
             'simple php file' => array(<<<'EOL'

--- a/tests/Composer/Test/Installer/InstallationManagerTest.php
+++ b/tests/Composer/Test/Installer/InstallationManagerTest.php
@@ -50,7 +50,7 @@ class InstallationManagerTest extends TestCase
         $installer
             ->expects($this->exactly(2))
             ->method('supports')
-            ->will($this->returnCallback(function ($arg) {
+            ->will($this->returnCallback(function ($arg): bool {
                 return $arg === 'vendor';
             }));
 
@@ -70,7 +70,7 @@ class InstallationManagerTest extends TestCase
         $installer
             ->expects($this->exactly(2))
             ->method('supports')
-            ->will($this->returnCallback(function ($arg) {
+            ->will($this->returnCallback(function ($arg): bool {
                 return $arg === 'vendor';
             }));
 
@@ -79,7 +79,7 @@ class InstallationManagerTest extends TestCase
         $installer2
             ->expects($this->exactly(1))
             ->method('supports')
-            ->will($this->returnCallback(function ($arg) {
+            ->will($this->returnCallback(function ($arg): bool {
                 return $arg === 'vendor';
             }));
 
@@ -212,7 +212,7 @@ class InstallationManagerTest extends TestCase
         $bundleInstaller
             ->expects($this->exactly(2))
             ->method('supports')
-            ->will($this->returnCallback(function ($arg) {
+            ->will($this->returnCallback(function ($arg): bool {
                 return $arg === 'bundles';
             }));
 

--- a/tests/Composer/Test/InstallerTest.php
+++ b/tests/Composer/Test/InstallerTest.php
@@ -122,7 +122,7 @@ class InstallerTest extends TestCase
             }));
         $lockJsonMock->expects($this->any())
             ->method('exists')
-            ->will($this->returnCallback(function () use (&$lockData) {
+            ->will($this->returnCallback(function () use (&$lockData): bool {
                 return $lockData !== null;
             }));
         $lockJsonMock->expects($this->any())
@@ -172,7 +172,7 @@ class InstallerTest extends TestCase
         return $comparable;
     }
 
-    public function provideInstaller()
+    public function provideInstaller(): array
     {
         $cases = array();
 
@@ -348,7 +348,7 @@ class InstallerTest extends TestCase
             }));
         $lockJsonMock->expects($this->any())
             ->method('exists')
-            ->will($this->returnCallback(function () use (&$lockData) {
+            ->will($this->returnCallback(function () use (&$lockData): bool {
                 return $lockData !== null;
             }));
         $lockJsonMock->expects($this->any())
@@ -390,7 +390,7 @@ class InstallerTest extends TestCase
         $install->addOption('ignore-platform-req', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
         $install->addOption('no-dev', null, InputOption::VALUE_NONE);
         $install->addOption('dry-run', null, InputOption::VALUE_NONE);
-        $install->setCode(function ($input, $output) use ($installer) {
+        $install->setCode(function ($input, $output) use ($installer): int {
             $ignorePlatformReqs = $input->getOption('ignore-platform-reqs') ?: ($input->getOption('ignore-platform-req') ?: false);
 
             $installer
@@ -414,9 +414,9 @@ class InstallerTest extends TestCase
         $update->addOption('prefer-stable', null, InputOption::VALUE_NONE);
         $update->addOption('prefer-lowest', null, InputOption::VALUE_NONE);
         $update->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL);
-        $update->setCode(function ($input, $output) use ($installer) {
+        $update->setCode(function ($input, $output) use ($installer): int {
             $packages = $input->getArgument('packages');
-            $filteredPackages = array_filter($packages, function ($package) {
+            $filteredPackages = array_filter($packages, function ($package): bool {
                 return !in_array($package, array('lock', 'nothing', 'mirrors'), true);
             });
             $updateMirrors = $input->getOption('lock') || count($filteredPackages) != count($packages);
@@ -483,7 +483,7 @@ class InstallerTest extends TestCase
                 $actualInstalled[] = $package;
             }
 
-            usort($actualInstalled, function ($a, $b) {
+            usort($actualInstalled, function ($a, $b): int {
                 return strcmp($a['name'], $b['name']);
             });
 
@@ -502,12 +502,12 @@ class InstallerTest extends TestCase
         }
     }
 
-    public function provideSlowIntegrationTests()
+    public function provideSlowIntegrationTests(): array
     {
         return $this->loadIntegrationTests('installer-slow/');
     }
 
-    public function provideIntegrationTests()
+    public function provideIntegrationTests(): array
     {
         return $this->loadIntegrationTests('installer/');
     }

--- a/tests/Composer/Test/Json/JsonManipulatorTest.php
+++ b/tests/Composer/Test/Json/JsonManipulatorTest.php
@@ -32,7 +32,7 @@ class JsonManipulatorTest extends TestCase
         $this->assertEquals($expected, $manipulator->getContents());
     }
 
-    public function linkProvider()
+    public function linkProvider(): array
     {
         return array(
             array(
@@ -1308,7 +1308,7 @@ class JsonManipulatorTest extends TestCase
         $this->assertEquals($expected, $manipulator->getContents());
     }
 
-    public function providerAddLinkAndSortPackages()
+    public function providerAddLinkAndSortPackages(): array
     {
         return array(
             array(
@@ -1395,7 +1395,7 @@ class JsonManipulatorTest extends TestCase
         }
     }
 
-    public function removeSubNodeProvider()
+    public function removeSubNodeProvider(): array
     {
         return array(
             'works on simple ones first' => array(

--- a/tests/Composer/Test/Json/JsonValidationExceptionTest.php
+++ b/tests/Composer/Test/Json/JsonValidationExceptionTest.php
@@ -35,7 +35,7 @@ class JsonValidationExceptionTest extends TestCase
         $this->assertEquals(array(), $object->getErrors());
     }
 
-    public function errorProvider()
+    public function errorProvider(): array
     {
         return array(
             array('test message', array(), 'test message', []),

--- a/tests/Composer/Test/Mock/HttpDownloaderMock.php
+++ b/tests/Composer/Test/Mock/HttpDownloaderMock.php
@@ -91,7 +91,7 @@ class HttpDownloaderMock extends HttpDownloader
         }
 
         if (count($this->expectations) > 0) {
-            $expectations = array_map(function ($expect) {
+            $expectations = array_map(function ($expect): string {
                 return $expect['url'];
             }, $this->expectations);
             throw new AssertionFailedError(

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -174,7 +174,7 @@ class ProcessExecutorMock extends ProcessExecutor
         return $return;
     }
 
-    public function executeAsync($command, $cwd = null): \React\Promise\Promise
+    public function executeAsync($command, $cwd = null): PromiseInterface
     {
         $resolver = function ($resolve, $reject): void {
             // TODO strictly speaking this should resolve with a mock Process instance here

--- a/tests/Composer/Test/Mock/ProcessExecutorMock.php
+++ b/tests/Composer/Test/Mock/ProcessExecutorMock.php
@@ -53,7 +53,7 @@ class ProcessExecutorMock extends ProcessExecutor
     {
         /** @var array{cmd: string|list<string>, return?: int, stdout?: string, stderr?: string, callback?: callable} $default */
         $default = array('cmd' => '', 'return' => 0, 'stdout' => '', 'stderr' => '', 'callback' => null);
-        $this->expectations = array_map(function ($expect) use ($default) {
+        $this->expectations = array_map(function ($expect) use ($default): array {
             if (is_string($expect)) {
                 $command = $expect;
                 $expect = $default;
@@ -89,7 +89,7 @@ class ProcessExecutorMock extends ProcessExecutor
         }
 
         if (count($this->expectations) > 0) {
-            $expectations = array_map(function ($expect) {
+            $expectations = array_map(function ($expect): string {
                 return is_array($expect['cmd']) ? implode(' ', $expect['cmd']) : $expect['cmd'];
             }, $this->expectations);
             throw new AssertionFailedError(
@@ -174,7 +174,7 @@ class ProcessExecutorMock extends ProcessExecutor
         return $return;
     }
 
-    public function executeAsync($command, $cwd = null): PromiseInterface
+    public function executeAsync($command, $cwd = null): \React\Promise\Promise
     {
         $resolver = function ($resolve, $reject): void {
             // TODO strictly speaking this should resolve with a mock Process instance here

--- a/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
+++ b/tests/Composer/Test/Package/Archiver/GitExcludeFilterTest.php
@@ -30,7 +30,7 @@ class GitExcludeFilterTest extends TestCase
         $this->assertEquals($expected, $filter->parseGitAttributesLine($ignore));
     }
 
-    public function providePatterns()
+    public function providePatterns(): array
     {
         return array(
             array('app/config/parameters.yml export-ignore', array('{(?=[^\.])app/(?=[^\.])config/(?=[^\.])parameters\.yml(?=$|/)}', false, false)),

--- a/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
+++ b/tests/Composer/Test/Package/Archiver/ZipArchiverTest.php
@@ -31,7 +31,7 @@ class ZipArchiverTest extends ArchiverTest
         ));
     }
 
-    public function provideGitignoreExcludeNegationTestCases()
+    public function provideGitignoreExcludeNegationTestCases(): array
     {
         return array(
             array('!/docs'),

--- a/tests/Composer/Test/Package/BasePackageTest.php
+++ b/tests/Composer/Test/Package/BasePackageTest.php
@@ -54,7 +54,7 @@ class BasePackageTest extends TestCase
         $this->assertSame($expected, $package->getFullPrettyVersion($truncate));
     }
 
-    public function provideFormattedVersions()
+    public function provideFormattedVersions(): array
     {
         $data = array(
             array(
@@ -79,7 +79,7 @@ class BasePackageTest extends TestCase
             ),
         );
 
-        $createPackage = function ($arr) {
+        $createPackage = function ($arr): array {
             $package = $this->getMockForAbstractClass('\Composer\Package\BasePackage', array(), '', false);
             $package->expects($this->once())->method('isDev')->will($this->returnValue(true));
             $package->expects($this->any())->method('getSourceType')->will($this->returnValue('git'));

--- a/tests/Composer/Test/Package/CompletePackageTest.php
+++ b/tests/Composer/Test/Package/CompletePackageTest.php
@@ -23,7 +23,7 @@ class CompletePackageTest extends TestCase
      *
      * demonstrates several versioning schemes
      */
-    public function providerVersioningSchemes()
+    public function providerVersioningSchemes(): array
     {
         $provider[] = array('foo',              '1-beta');
         $provider[] = array('node',             '0.5.6');

--- a/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
+++ b/tests/Composer/Test/Package/Dumper/ArrayDumperTest.php
@@ -111,7 +111,7 @@ class ArrayDumperTest extends TestCase
         $this->assertSame($expectedValue ?: $value, $config[$key]);
     }
 
-    public function provideKeys()
+    public function provideKeys(): array
     {
         return array(
             array(
@@ -247,8 +247,6 @@ class ArrayDumperTest extends TestCase
     /**
      * @param string $method
      * @param mixed  $value
-     *
-     * @return self
      */
     private function packageExpects($method, $value): \Composer\Test\Package\Dumper\ArrayDumperTest
     {

--- a/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ArrayLoaderTest.php
@@ -84,7 +84,7 @@ class ArrayLoaderTest extends TestCase
         $this->assertEquals('1.2.3.4', $package->getVersion());
     }
 
-    public function parseDumpProvider()
+    public function parseDumpProvider(): array
     {
         $validConfig = array(
             'name' => 'A/B',
@@ -273,7 +273,7 @@ class ArrayLoaderTest extends TestCase
         $this->assertFalse($package->isAbandoned());
     }
 
-    public function providePluginApiVersions()
+    public function providePluginApiVersions(): array
     {
         return array(
             array('1.0'),

--- a/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/RootPackageLoaderTest.php
@@ -28,7 +28,7 @@ class RootPackageLoaderTest extends TestCase
      *
      * @return RootPackage|RootAliasPackage
      */
-    protected function loadPackage($data)
+    protected function loadPackage($data): \Composer\Package\PackageInterface
     {
         $manager = $this->getMockBuilder('Composer\\Repository\\RepositoryManager')
             ->disableOriginalConstructor()

--- a/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
+++ b/tests/Composer/Test/Package/Loader/ValidatingArrayLoaderTest.php
@@ -35,7 +35,7 @@ class ValidatingArrayLoaderTest extends TestCase
         $loader->load($config);
     }
 
-    public function successProvider()
+    public function successProvider(): array
     {
         return array(
             array( // minimal
@@ -270,7 +270,7 @@ class ValidatingArrayLoaderTest extends TestCase
         $loader->load($config);
     }
 
-    public function errorProvider()
+    public function errorProvider(): array
     {
         $invalidNames = array(
             'foo',
@@ -420,7 +420,7 @@ class ValidatingArrayLoaderTest extends TestCase
         ));
     }
 
-    public function warningProvider()
+    public function warningProvider(): array
     {
         return array(
             array(

--- a/tests/Composer/Test/Package/Version/VersionParserTest.php
+++ b/tests/Composer/Test/Package/Version/VersionParserTest.php
@@ -30,7 +30,7 @@ class VersionParserTest extends TestCase
         $this->assertSame($result, $versionParser->parseNameVersionPairs($pairs));
     }
 
-    public function provideParseNameVersionPairsData()
+    public function provideParseNameVersionPairsData(): array
     {
         return array(
             array(array('php:^7.0'), array(array('name' => 'php', 'version' => '^7.0'))),
@@ -53,7 +53,7 @@ class VersionParserTest extends TestCase
         $this->assertSame($expected, VersionParser::isUpgrade($from, $to));
     }
 
-    public function provideIsUpgradeTests()
+    public function provideIsUpgradeTests(): array
     {
         return array(
             array('0.9.0.0', '1.0.0.0', true),

--- a/tests/Composer/Test/Package/Version/VersionSelectorTest.php
+++ b/tests/Composer/Test/Package/Version/VersionSelectorTest.php
@@ -317,7 +317,7 @@ class VersionSelectorTest extends TestCase
         $this->assertSame($expectedVersion, $recommended);
     }
 
-    public function provideRecommendedRequireVersionPackages()
+    public function provideRecommendedRequireVersionPackages(): array
     {
         return array(
             // real version, expected recommendation, [branch-alias], [pkg name]

--- a/tests/Composer/Test/Platform/VersionTest.php
+++ b/tests/Composer/Test/Platform/VersionTest.php
@@ -27,7 +27,7 @@ class VersionTest extends TestCase
      * 2) git log --pretty=%h --all -- crypto/opensslv.h include/openssl/opensslv.h | while read hash ; do (git show $hash:crypto/opensslv.h; git show $hash:include/openssl/opensslv.h)  | grep "define OPENSSL_VERSION_TEXT"  ; done > versions.txt
      * 3) cat versions.txt | awk -F "OpenSSL " '{print $2}'  | awk -F " " '{print $1}' | sed -e "s:\([0-9]*\.[0-9]*\.[0-9]*\):1.2.3:g" -e "s:1\.2\.3[a-z]\(-.*\)\{0,1\}$:1.2.3a\1:g"  -e "s:1\.2\.3[a-z]\{2\}\(-.*\)\{0,1\}$:1.2.3zh\1:g"  -e "s:beta[0-9]:beta3:g"  -e "s:pre[0-9]*:pre2:g" | sort | uniq
      */
-    public static function provideOpenSslVersions()
+    public static function provideOpenSslVersions(): array
     {
         return array(
             // Generated
@@ -88,7 +88,7 @@ class VersionTest extends TestCase
         self::assertSame($normalizedVersion, $this->getVersionParser()->normalize($parsedVersion));
     }
 
-    public function provideLibJpegVersions()
+    public function provideLibJpegVersions(): array
     {
         return array(
             array('9', '9.0'),
@@ -109,7 +109,7 @@ class VersionTest extends TestCase
         self::assertSame($parsedVersion, Version::parseLibjpeg($input));
     }
 
-    public function provideZoneinfoVersions()
+    public function provideZoneinfoVersions(): array
     {
         return array(
             array('2019c', '2019.3'),

--- a/tests/Composer/Test/Plugin/PluginInstallerTest.php
+++ b/tests/Composer/Test/Plugin/PluginInstallerTest.php
@@ -96,7 +96,7 @@ class PluginInstallerTest extends TestCase
         $im = $this->getMockBuilder('Composer\Installer\InstallationManager')->disableOriginalConstructor()->getMock();
         $im->expects($this->any())
             ->method('getInstallPath')
-            ->will($this->returnCallback(function ($package) {
+            ->will($this->returnCallback(function ($package): string {
                 return __DIR__.'/Fixtures/'.$package->getPrettyName();
             }));
 
@@ -303,7 +303,7 @@ class PluginInstallerTest extends TestCase
         $this->repository
             ->expects($this->any())
             ->method('getPackages')
-            ->will($this->returnCallback(function () use ($plugApiInternalPackage, $plugins) {
+            ->will($this->returnCallback(function () use ($plugApiInternalPackage, $plugins): array {
                 return array_merge(array($plugApiInternalPackage), $plugins);
             }));
 
@@ -394,7 +394,7 @@ class PluginInstallerTest extends TestCase
 
         $plugin->expects($this->once())
                ->method('getCapabilities')
-               ->will($this->returnCallback(function () use ($capabilityImplementation, $capabilityApi) {
+               ->will($this->returnCallback(function () use ($capabilityImplementation, $capabilityApi): array {
                    return array($capabilityApi => $capabilityImplementation);
                }));
 
@@ -448,7 +448,7 @@ class PluginInstallerTest extends TestCase
 
         $plugin->expects($this->once())
                ->method('getCapabilities')
-               ->will($this->returnCallback(function () use ($invalidImplementationClassNames, $capabilityApi) {
+               ->will($this->returnCallback(function () use ($invalidImplementationClassNames, $capabilityApi): array {
                    return array($capabilityApi => $invalidImplementationClassNames);
                }));
 
@@ -465,7 +465,7 @@ class PluginInstallerTest extends TestCase
 
         $plugin->expects($this->once())
                ->method('getCapabilities')
-               ->will($this->returnCallback(function () {
+               ->will($this->returnCallback(function (): array {
                    return array();
                }));
 

--- a/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ArtifactRepositoryTest.php
@@ -53,7 +53,7 @@ class ArtifactRepositoryTest extends TestCase
 
         $this->assertSame($expectedPackages, $foundPackages);
 
-        $tarPackage = array_filter($repo->getPackages(), function (BasePackage $package) {
+        $tarPackage = array_filter($repo->getPackages(), function (BasePackage $package): bool {
             return $package->getPrettyName() === 'test/jsonInRootTarFile';
         });
         $this->assertCount(1, $tarPackage);

--- a/tests/Composer/Test/Repository/ComposerRepositoryTest.php
+++ b/tests/Composer/Test/Repository/ComposerRepositoryTest.php
@@ -61,7 +61,7 @@ class ComposerRepositoryTest extends TestCase
         }
     }
 
-    public function loadDataProvider()
+    public function loadDataProvider(): array
     {
         return array(
             // Old repository format
@@ -303,7 +303,7 @@ class ComposerRepositoryTest extends TestCase
         $this->assertSame($expected, $method->invoke($repository, $url));
     }
 
-    public function provideCanonicalizeUrlTestCases()
+    public function provideCanonicalizeUrlTestCases(): array
     {
         return array(
             array(

--- a/tests/Composer/Test/Repository/CompositeRepositoryTest.php
+++ b/tests/Composer/Test/Repository/CompositeRepositoryTest.php
@@ -138,7 +138,7 @@ class CompositeRepositoryTest extends TestCase
         $this->assertEquals(array(), call_user_func_array(array($repo, $method), $args));
     }
 
-    public function provideMethodCalls()
+    public function provideMethodCalls(): array
     {
         return array(
             array('findPackages', array('foo')),

--- a/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilesystemRepositoryTest.php
@@ -171,7 +171,7 @@ class FilesystemRepositoryTest extends TestCase
             ->getMock();
         $im->expects($this->any())
             ->method('getInstallPath')
-            ->will($this->returnCallback(function ($package) use ($dir) {
+            ->will($this->returnCallback(function ($package) use ($dir): string {
                 // check for empty paths handling
                 if ($package->getType() === 'metapackage') {
                     return '';

--- a/tests/Composer/Test/Repository/FilterRepositoryTest.php
+++ b/tests/Composer/Test/Repository/FilterRepositoryTest.php
@@ -45,12 +45,12 @@ class FilterRepositoryTest extends TestCase
         $repo = new FilterRepository($this->arrayRepo, $config);
         $packages = $repo->getPackages();
 
-        $this->assertSame($expected, array_map(function ($p) {
+        $this->assertSame($expected, array_map(function ($p): string {
             return $p->getName();
         }, $packages));
     }
 
-    public static function provideRepoMatchingTestCases()
+    public static function provideRepoMatchingTestCases(): array
     {
         return array(
             array(array('foo/aaa', 'foo/bbb'), array('only' => array('foo/*'))),

--- a/tests/Composer/Test/Repository/PlatformRepositoryTest.php
+++ b/tests/Composer/Test/Repository/PlatformRepositoryTest.php
@@ -36,7 +36,7 @@ class PlatformRepositoryTest extends TestCase
         self::assertSame('2.1.0', $hhvm->getPrettyVersion());
     }
 
-    public function providePhpFlavorTestCases()
+    public function providePhpFlavorTestCases(): array
     {
         return array(
             array(
@@ -128,7 +128,7 @@ class PlatformRepositoryTest extends TestCase
             ->willReturn(array());
         $runtime
             ->method('hasConstant')
-            ->willReturnCallback(function ($constant, $class = null) use ($constants) {
+            ->willReturnCallback(function ($constant, $class = null) use ($constants): bool {
                 return isset($constants[ltrim($class.'::'.$constant, ':')]);
             });
         $runtime
@@ -178,7 +178,7 @@ class PlatformRepositoryTest extends TestCase
         self::assertNull($package);
     }
 
-    public static function provideLibraryTestCases()
+    public static function provideLibraryTestCases(): array
     {
         return array(
             'amqp' => array(
@@ -1103,7 +1103,7 @@ Linked Version => 1.2.11',
         $runtime
             ->method('getExtensionVersion')
             ->willReturnMap(
-                array_map(function ($extension) use ($extensionVersion) {
+                array_map(function ($extension) use ($extensionVersion): array {
                     return array($extension, $extensionVersion);
                 }, $extensions)
             );
@@ -1111,7 +1111,7 @@ Linked Version => 1.2.11',
         $runtime
             ->method('getExtensionInfo')
             ->willReturnMap(
-                array_map(function ($extension) use ($info) {
+                array_map(function ($extension) use ($info): array {
                     return array($extension, $info);
                 }, $extensions)
             );
@@ -1123,7 +1123,7 @@ Linked Version => 1.2.11',
         $constants[] = array('PHP_VERSION', null, '7.1.0');
         $runtime
             ->method('hasConstant')
-            ->willReturnCallback(function ($constant, $class = null) use ($constants) {
+            ->willReturnCallback(function ($constant, $class = null) use ($constants): bool {
                 foreach ($constants as $definition) {
                     if ($definition[0] === $constant && $definition[1] === $class) {
                         return true;
@@ -1138,7 +1138,7 @@ Linked Version => 1.2.11',
 
         $runtime
             ->method('hasClass')
-            ->willReturnCallback(function ($class) use ($classDefinitions) {
+            ->willReturnCallback(function ($class) use ($classDefinitions): bool {
                 foreach ($classDefinitions as $definition) {
                     if ($definition[0] === $class) {
                         return true;
@@ -1153,27 +1153,27 @@ Linked Version => 1.2.11',
 
         $platformRepository = new PlatformRepository(array(), array(), $runtime);
 
-        $expectations = array_map(function ($expectation) {
+        $expectations = array_map(function ($expectation): array {
             return array_replace(array(null, array(), array()), (array) $expectation);
         }, $expectations);
 
         $libraries = array_map(
-            function ($package) {
+            function ($package): string {
                 return $package['name'];
             },
             array_filter(
                 $platformRepository->search('lib', PlatformRepository::SEARCH_NAME),
-                function ($package) {
+                function ($package): bool {
                     return strpos($package['name'], 'lib-') === 0;
                 }
             )
         );
-        $expectedLibraries = array_merge(array_keys(array_filter($expectations, function ($expectation) {
+        $expectedLibraries = array_merge(array_keys(array_filter($expectations, function ($expectation): bool {
             return $expectation[0] !== false;
         })));
         self::assertCount(count(array_filter($expectedLibraries)), $libraries, sprintf('Expected: %s, got %s', var_export($expectedLibraries, true), var_export($libraries, true)));
 
-        $expectations = array_merge($expectations, array_combine(array_map(function ($extension) {
+        $expectations = array_merge($expectations, array_combine(array_map(function ($extension): string {
             return 'ext-'.$extension;
         }, $extensions), array_fill(0, count($extensions), array($extensionVersion, array(), array()))));
 
@@ -1231,7 +1231,7 @@ Linked Version => 1.2.11',
         self::assertNotNull($package, 'Composer package exists');
     }
 
-    public static function providePlatformPackages()
+    public static function providePlatformPackages(): array
     {
         return array(
             array('php', true),

--- a/tests/Composer/Test/Repository/RepositoryFactoryTest.php
+++ b/tests/Composer/Test/Repository/RepositoryFactoryTest.php
@@ -63,7 +63,7 @@ class RepositoryFactoryTest extends TestCase
         $this->assertSame($expected, RepositoryFactory::generateRepositoryName($index, $config, $existingRepos));
     }
 
-    public function generateRepositoryNameProvider()
+    public function generateRepositoryNameProvider(): array
     {
         return array(
             array(0, array(), array(), '0'),

--- a/tests/Composer/Test/Repository/RepositoryManagerTest.php
+++ b/tests/Composer/Test/Repository/RepositoryManagerTest.php
@@ -76,7 +76,7 @@ class RepositoryManagerTest extends TestCase
         $config
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function ($arg) use ($tmpdir) {
+            ->will($this->returnCallback(function ($arg) use ($tmpdir): ?string {
                 return 'cache-repo-dir' === $arg ? $tmpdir : null;
             }))
         ;
@@ -95,7 +95,7 @@ class RepositoryManagerTest extends TestCase
         $this->assertInstanceOf('Composer\Repository\RepositoryInterface', $rm->createRepository($type, $options));
     }
 
-    public function provideRepoCreationTestCases()
+    public function provideRepoCreationTestCases(): array
     {
         $cases = array(
             array('composer', array('url' => 'http://example.org')),

--- a/tests/Composer/Test/Repository/Vcs/FossilDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/FossilDriverTest.php
@@ -46,7 +46,7 @@ class FossilDriverTest extends TestCase
         $fs->removeDirectory($this->home);
     }
 
-    public static function supportProvider()
+    public static function supportProvider(): array
     {
         return array(
             array('http://fossil.kd2.org/kd2fw/', true),

--- a/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitBitbucketDriverTest.php
@@ -99,7 +99,7 @@ class GitBitbucketDriverTest extends TestCase
         $driver->getRootIdentifier();
     }
 
-    public function testDriver()
+    public function testDriver(): \Composer\Repository\Vcs\GitBitbucketDriver
     {
         $driver = $this->getDriver(array('url' => 'https://bitbucket.org/user/repo.git'));
 

--- a/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/GitLabDriverTest.php
@@ -77,7 +77,7 @@ class GitLabDriverTest extends TestCase
         $fs->removeDirectory($this->home);
     }
 
-    public function provideInitializeUrls()
+    public function provideInitializeUrls(): array
     {
         return array(
             array('https://gitlab.com/mygroup/myproject', 'https://gitlab.com/api/v4/projects/mygroup%2Fmyproject'),
@@ -92,7 +92,7 @@ class GitLabDriverTest extends TestCase
      * @param string $url
      * @param string $apiUrl
      */
-    public function testInitialize($url, $apiUrl)
+    public function testInitialize($url, $apiUrl): \Composer\Repository\Vcs\GitLabDriver
     {
         // @link http://doc.gitlab.com/ce/api/projects.html#get-single-project
         $projectData = <<<JSON
@@ -135,7 +135,7 @@ JSON;
      * @param string $url
      * @param string $apiUrl
      */
-    public function testInitializePublicProject($url, $apiUrl)
+    public function testInitializePublicProject($url, $apiUrl): \Composer\Repository\Vcs\GitLabDriver
     {
         // @link http://doc.gitlab.com/ce/api/projects.html#get-single-project
         $projectData = <<<JSON
@@ -176,7 +176,7 @@ JSON;
      * @param string $url
      * @param string $apiUrl
      */
-    public function testInitializePublicProjectAsAnonymous($url, $apiUrl)
+    public function testInitializePublicProjectAsAnonymous($url, $apiUrl): \Composer\Repository\Vcs\GitLabDriver
     {
         // @link http://doc.gitlab.com/ce/api/projects.html#get-single-project
         $projectData = <<<JSON
@@ -449,7 +449,7 @@ JSON;
         $this->assertSame($expected, GitLabDriver::supports($this->io, $this->config, $url));
     }
 
-    public function dataForTestSupports()
+    public function dataForTestSupports(): array
     {
         return array(
             array('http://gitlab.com/foo/bar', true),

--- a/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/HgDriverTest.php
@@ -57,7 +57,7 @@ class HgDriverTest extends TestCase
         );
     }
 
-    public function supportsDataProvider()
+    public function supportsDataProvider(): array
     {
         return array(
             array('ssh://bitbucket.org/user/repo'),

--- a/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
+++ b/tests/Composer/Test/Repository/Vcs/SvnDriverTest.php
@@ -84,7 +84,7 @@ class SvnDriverTest extends TestCase
         $svn->initialize();
     }
 
-    public static function supportProvider()
+    public static function supportProvider(): array
     {
         return array(
             array('http://svn.apache.org', true),

--- a/tests/Composer/Test/TestCase.php
+++ b/tests/Composer/Test/TestCase.php
@@ -135,7 +135,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param string $version
      * @return AliasPackage|RootAliasPackage|CompleteAliasPackage
      */
-    protected function getAliasPackage(Package $package, $version)
+    protected function getAliasPackage(Package $package, $version): \Composer\Package\AliasPackage
     {
         $normVersion = self::getVersionParser()->normalize($version);
 

--- a/tests/Composer/Test/Util/AuthHelperTest.php
+++ b/tests/Composer/Test/Util/AuthHelperTest.php
@@ -145,7 +145,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function gitlabPrivateTokenProvider()
+    public function gitlabPrivateTokenProvider(): array
     {
         return array(
           array('private-token'),
@@ -222,7 +222,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function bitbucketPublicUrlProvider()
+    public function bitbucketPublicUrlProvider(): array
     {
         return array(
             array('https://bitbucket.org/user/repo/downloads/whatever'),
@@ -260,7 +260,7 @@ class AuthHelperTest extends TestCase
         );
     }
 
-    public function basicHttpAuthenticationProvider()
+    public function basicHttpAuthenticationProvider(): array
     {
         return array(
             array(
@@ -416,7 +416,7 @@ class AuthHelperTest extends TestCase
                 null,
                 'y'
             )
-            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer) {
+            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer): string {
                 $validator($answer);
 
                 return $answer;
@@ -464,7 +464,7 @@ class AuthHelperTest extends TestCase
                 null,
                 'y'
             )
-            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer) {
+            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer): string {
                 $validator($answer);
 
                 return $answer;
@@ -504,7 +504,7 @@ class AuthHelperTest extends TestCase
                 null,
                 'y'
             )
-            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer) {
+            ->willReturnCallback(function ($question, $validator, $attempts, $default) use ($answer): string {
                 $validator($answer);
 
                 return $answer;

--- a/tests/Composer/Test/Util/BitbucketTest.php
+++ b/tests/Composer/Test/Util/BitbucketTest.php
@@ -111,7 +111,7 @@ class BitbucketTest extends TestCase
         );
     }
 
-    public function testRequestAccessTokenWithValidOAuthConsumerAndValidStoredAccessToken()
+    public function testRequestAccessTokenWithValidOAuthConsumerAndValidStoredAccessToken(): \Composer\Util\Bitbucket
     {
         $this->config->expects($this->once())
             ->method('get')

--- a/tests/Composer/Test/Util/FilesystemTest.php
+++ b/tests/Composer/Test/Util/FilesystemTest.php
@@ -65,7 +65,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->findShortestPathCode($a, $b, $directory, $static));
     }
 
-    public function providePathCouplesAsCode()
+    public function providePathCouplesAsCode(): array
     {
         return array(
             array('/foo/bar', '/foo/bar', false, "__FILE__"),
@@ -128,7 +128,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->findShortestPath($a, $b, $directory));
     }
 
-    public function providePathCouples()
+    public function providePathCouples(): array
     {
         return array(
             array('/foo/bar', '/foo/bar', "./bar"),
@@ -213,7 +213,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expected, $fs->normalizePath($actual));
     }
 
-    public function provideNormalizedPaths()
+    public function provideNormalizedPaths(): array
     {
         return array(
             array('../foo', '../foo'),

--- a/tests/Composer/Test/Util/GitTest.php
+++ b/tests/Composer/Test/Util/GitTest.php
@@ -49,7 +49,7 @@ class GitTest extends TestCase
      */
     public function testRunCommandPublicGitHubRepositoryNotInitialClone($protocol, $expectedUrl): void
     {
-        $commandCallable = function ($url) use ($expectedUrl) {
+        $commandCallable = function ($url) use ($expectedUrl): string {
             $this->assertSame($expectedUrl, $url);
 
             return 'git command';
@@ -62,7 +62,7 @@ class GitTest extends TestCase
         $this->git->runCommand($commandCallable, 'https://github.com/acme/repo', null, true);
     }
 
-    public function publicGithubNoCredentialsProvider()
+    public function publicGithubNoCredentialsProvider(): array
     {
         return array(
             array('ssh', 'git@github.com:acme/repo'),
@@ -74,7 +74,7 @@ class GitTest extends TestCase
     {
         self::expectException('RuntimeException');
 
-        $commandCallable = function ($url) {
+        $commandCallable = function ($url): string {
             $this->assertSame('https://github.com/acme/repo', $url);
 
             return 'git command';
@@ -101,7 +101,7 @@ class GitTest extends TestCase
      */
     public function testRunCommandPrivateGitHubRepositoryNotInitialCloneNotInteractiveWithAuthentication($gitUrl, $protocol, $gitHubToken, $expectedUrl, $expectedFailuresBeforeSuccess): void
     {
-        $commandCallable = function ($url) use ($expectedUrl) {
+        $commandCallable = function ($url) use ($expectedUrl): string {
             if ($url !== $expectedUrl) {
                 return 'git command failing';
             }
@@ -135,7 +135,7 @@ class GitTest extends TestCase
         $this->git->runCommand($commandCallable, $gitUrl, null, true);
     }
 
-    public function privateGithubWithCredentialsProvider()
+    public function privateGithubWithCredentialsProvider(): array
     {
         return array(
             array('git@github.com:acme/repo.git', 'ssh', 'MY_GITHUB_TOKEN', 'https://token:MY_GITHUB_TOKEN@github.com/acme/repo.git', 1),

--- a/tests/Composer/Test/Util/Http/ProxyHelperTest.php
+++ b/tests/Composer/Test/Util/Http/ProxyHelperTest.php
@@ -57,7 +57,7 @@ class ProxyHelperTest extends TestCase
         ProxyHelper::getProxyData();
     }
 
-    public function dataMalformed()
+    public function dataMalformed(): array
     {
         return array(
             'no-host' => array('localhost'),
@@ -79,7 +79,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $httpProxy);
     }
 
-    public function dataFormatting()
+    public function dataFormatting(): array
     {
         // url, expected
         return array(
@@ -104,7 +104,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $list[$index]);
     }
 
-    public function dataCaseOverrides()
+    public function dataCaseOverrides(): array
     {
         // server, expected, list index
         return array(
@@ -129,7 +129,7 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, $list[$index]);
     }
 
-    public function dataCGIOverrides()
+    public function dataCGIOverrides(): array
     {
         // server, expected, list index
         return array(
@@ -167,7 +167,7 @@ class ProxyHelperTest extends TestCase
         $this->assertEquals($expected, ProxyHelper::getContextOptions($url));
     }
 
-    public function dataContextOptions()
+    public function dataContextOptions(): array
     {
         // url, expected
         return array(
@@ -198,7 +198,7 @@ class ProxyHelperTest extends TestCase
         $this->assertEquals($expected, $options);
     }
 
-    public function dataRequestFullUri()
+    public function dataRequestFullUri(): array
     {
         $options = array('http' => array('request_fulluri' => true));
 

--- a/tests/Composer/Test/Util/Http/ProxyManagerTest.php
+++ b/tests/Composer/Test/Util/Http/ProxyManagerTest.php
@@ -100,7 +100,7 @@ class ProxyManagerTest extends TestCase
         $this->assertTrue($condition, 'lastProxy check');
     }
 
-    public function dataRequest()
+    public function dataRequest(): array
     {
         $server = array(
             'http_proxy' => 'http://user:p%40ss@proxy.com',
@@ -156,7 +156,7 @@ class ProxyManagerTest extends TestCase
         $this->assertTrue($condition, 'message check');
     }
 
-    public function dataStatus()
+    public function dataStatus(): array
     {
         // server, expectedStatus, expectedMessage
         return array(

--- a/tests/Composer/Test/Util/Http/RequestProxyTest.php
+++ b/tests/Composer/Test/Util/Http/RequestProxyTest.php
@@ -30,7 +30,7 @@ class RequestProxyTest extends TestCase
         $this->assertSame($expectedSecure, $proxy->isSecure());
     }
 
-    public function dataSecure()
+    public function dataSecure(): array
     {
         // url, secure
         return array(
@@ -55,7 +55,7 @@ class RequestProxyTest extends TestCase
         $this->assertSame($expected, $message);
     }
 
-    public function dataProxyUrl()
+    public function dataProxyUrl(): array
     {
         $format = 'proxy (%s)';
 

--- a/tests/Composer/Test/Util/NoProxyPatternTest.php
+++ b/tests/Composer/Test/Util/NoProxyPatternTest.php
@@ -31,7 +31,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataHostName()
+    public function dataHostName(): array
     {
         $noproxy = 'foobar.com, .barbaz.net';
 
@@ -62,7 +62,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataIpAddress()
+    public function dataIpAddress(): array
     {
         $noproxy = '192.168.1.1, 2001:db8::52:0:1';
 
@@ -91,7 +91,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataIpRange()
+    public function dataIpRange(): array
     {
         $noproxy = '10.0.0.0/30, 2002:db8:a::45/121';
 
@@ -120,7 +120,7 @@ class NoProxyPatternTest extends TestCase
         $this->assertEquals($expected, $matcher->test($url));
     }
 
-    public function dataPort()
+    public function dataPort(): array
     {
         $noproxy = '192.168.1.2:81, 192.168.1.3:80, [2001:db8::52:0:2]:443, [2001:db8::52:0:3]:80';
 

--- a/tests/Composer/Test/Util/PackageSorterTest.php
+++ b/tests/Composer/Test/Util/PackageSorterTest.php
@@ -32,7 +32,7 @@ class PackageSorterTest extends TestCase
         self::assertSame($packages, $sortedPackages);
     }
 
-    public function sortingOrdersDependenciesHigherThanPackageDataProvider()
+    public function sortingOrdersDependenciesHigherThanPackageDataProvider(): array
     {
         return array(
             'one package is dep' => array(
@@ -111,7 +111,7 @@ class PackageSorterTest extends TestCase
     public function testSortingOrdersDependenciesHigherThanPackage($packages, $expectedOrderedList): void
     {
         $sortedPackages = PackageSorter::sortPackages($packages);
-        $sortedPackageNames = array_map(function ($package) {
+        $sortedPackageNames = array_map(function ($package): string {
             return $package->getName();
         }, $sortedPackages);
 

--- a/tests/Composer/Test/Util/ProcessExecutorTest.php
+++ b/tests/Composer/Test/Util/ProcessExecutorTest.php
@@ -80,7 +80,7 @@ class ProcessExecutorTest extends TestCase
         $this->assertEquals('Executing command (CWD): ' . $expectedCommandOutput, trim($buffer->getOutput()));
     }
 
-    public function hidePasswordProvider()
+    public function hidePasswordProvider(): array
     {
         return array(
             array('echo https://foo:bar@example.org/', 'echo https://foo:***@example.org/'),
@@ -151,7 +151,7 @@ class ProcessExecutorTest extends TestCase
      * Each named test is an array of:
      *   argument, win-expected, unix-expected
      */
-    public function dataEscapeArguments()
+    public function dataEscapeArguments(): array
     {
         return array(
             // empty argument - must be quoted

--- a/tests/Composer/Test/Util/RemoteFilesystemTest.php
+++ b/tests/Composer/Test/Util/RemoteFilesystemTest.php
@@ -176,7 +176,7 @@ class RemoteFilesystemTest extends TestCase
         $fs = $this->getRemoteFilesystemWithMockedMethods(array('getRemoteContents'));
 
         $fs->expects($this->once())->method('getRemoteContents')
-            ->willReturnCallback(function ($originUrl, $fileUrl, $ctx, &$http_response_header) {
+            ->willReturnCallback(function ($originUrl, $fileUrl, $ctx, &$http_response_header): string {
                 $http_response_header = array('http/1.1 401 unauthorized');
 
                 return '';
@@ -313,7 +313,7 @@ class RemoteFilesystemTest extends TestCase
         $domains = array();
         $io
             ->method('hasAuthentication')
-            ->willReturnCallback(function ($arg) use (&$domains) {
+            ->willReturnCallback(function ($arg) use (&$domains): bool {
                 $domains[] = $arg;
                 // first time is called with bitbucket.org, then it redirects to bbuseruploads.s3.amazonaws.com so next time we have no auth configured
                 return $arg === 'bitbucket.org';

--- a/tests/Composer/Test/Util/StreamContextFactoryTest.php
+++ b/tests/Composer/Test/Util/StreamContextFactoryTest.php
@@ -49,7 +49,7 @@ class StreamContextFactoryTest extends TestCase
         $this->assertEquals($expectedParams, $params);
     }
 
-    public function dataGetContext()
+    public function dataGetContext(): array
     {
         return array(
             array(
@@ -192,7 +192,7 @@ class StreamContextFactoryTest extends TestCase
         }
     }
 
-    public function dataSSLProxy()
+    public function dataSSLProxy(): array
     {
         return array(
             array('ssl://proxyserver:443', 'https://proxyserver/'),

--- a/tests/Composer/Test/Util/SvnTest.php
+++ b/tests/Composer/Test/Util/SvnTest.php
@@ -36,7 +36,7 @@ class SvnTest extends TestCase
         $this->assertEquals($expect, $reflMethod->invoke($svn));
     }
 
-    public function urlProvider()
+    public function urlProvider(): array
     {
         return array(
             array('http://till:test@svn.example.org/', $this->getCmd(" --username 'till' --password 'test' ")),

--- a/tests/Composer/Test/Util/TlsHelperTest.php
+++ b/tests/Composer/Test/Util/TlsHelperTest.php
@@ -41,7 +41,7 @@ class TlsHelperTest extends TestCase
         }
     }
 
-    public function dataCheckCertificateHost()
+    public function dataCheckCertificateHost(): array
     {
         return array(
             array(true, 'getcomposer.org', array('getcomposer.org')),

--- a/tests/Composer/Test/Util/UrlTest.php
+++ b/tests/Composer/Test/Util/UrlTest.php
@@ -34,7 +34,7 @@ class UrlTest extends TestCase
         $this->assertSame($expectedUrl, Url::updateDistReference($config, $url, $ref));
     }
 
-    public static function distRefsProvider()
+    public static function distRefsProvider(): array
     {
         return array(
             // github
@@ -75,7 +75,7 @@ class UrlTest extends TestCase
         $this->assertSame($expected, Url::sanitize($url));
     }
 
-    public static function sanitizeProvider()
+    public static function sanitizeProvider(): array
     {
         return array(
             // with scheme


### PR DESCRIPTION
This would add all return types to tests based on following rector.php:

<details>
<summary>rector.php</summary>

```php
<?php

declare(strict_types=1);

use Rector\Core\Configuration\Option;
use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector;
use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    $parameters = $containerConfigurator->parameters();
    $services = $containerConfigurator->services();

    $parameters->set(Option::PATHS, [__DIR__ . '/tests']); // only tests directory
    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan/config.neon');

    // basic rules
    // $parameters->set(Option::AUTO_IMPORT_NAMES, true);
    $parameters->set(Option::IMPORT_DOC_BLOCKS, true);
    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);

    $services->set(AddClosureReturnTypeRector::class);
    $services->set(AddReturnTypeDeclarationRector::class);
    $services->set(AddVoidReturnTypeWhereNoReturnRector::class);
    $services->set(ReturnTypeFromReturnNewRector::class);
    $services->set(ReturnTypeFromStrictTypedCallRector::class);
    $services->set(ReturnTypeFromStrictTypedPropertyRector::class);

    $services->set(ReturnTypeDeclarationRector::class);
};
```

</details>

I manually reverted all files which where in `Fixtures` namespace. 

PHPStan is throwing new warnings because of new added `array` return types without specificy its type, not sure how to update phpstan baseline as there seems an own 8.1 baseline.